### PR TITLE
Remove Ruby 1.9.3 from deploy-time testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ notifications:
 script:
 - bundle exec rake default
 - gem build sensu-plugins-trafficserver.gemspec
-- gem install sensu-plugins-trafficserver-*.gem
+- gem install sensu-plugins-traffic-server-*.gem
 deploy:
   provider: rubygems
   api_key:
     secure: nSwTlcdjhzJxcKO1R6yef+jYLH1ZZINVPHYGKFGwrVvxROOIcef3CMa10Dwe+IchuarGYl4vhSIxB/yAIiaxv8u/887lfCn3hHJYPkMQ9UTLt7W8cy8tJhNAr7+YlSChx8HyPls7oMbyuWm3rqcyY7y+evnSxb/XMuG9LsfyAOg=
-  gem: sensu-plugins-trafficserver
+  gem: sensu-plugins-traffic-server
   on:
     tags: true
     all_branches: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
What's in Unreleased covers this change

- [x] Existing tests pass

#### Purpose

Ruby 1.9.3 is no longer supported so no need for deploy-time testing.

